### PR TITLE
Support hostnames that include "psql"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: 'Additional options supported by postgresql simple SQL shell. These options will be applied when executing the given file on the Azure DB for Postgresql. In case of multiple files, the same args will be applied for all files'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'

--- a/src/Utils/ActionInputs.ts
+++ b/src/Utils/ActionInputs.ts
@@ -24,7 +24,8 @@ export class ActionInputs {
     }
 
     private parseConnectionString() {
-        this._connectionString = this._connectionString.replace('psql', "").replace(/["]+/g, '').trim();
+        // Replace the "psql " part of the psql command copied from the Azure portal connection info
+        this._connectionString = this._connectionString.replace(/^psql\s/,'').replace(/["]+/g, '').trim();
         if (!this.validateConnectionString()) {
             throw new Error(`Please provide a valid connection string. A valid connection string is a series of keyword/value pairs separated by space. Spaces around the equal sign are optional. To write an empty value, or a value containing spaces, surround it with single quotes, e.g., keyword = 'a value'. Single quotes and backslashes within the value must be escaped with a backslash`);
         }


### PR DESCRIPTION
Support the original use case for the replace command for "psql" but don't touch the rest of the connection string.

Fixes: https://github.com/Azure/postgresql/issues/48